### PR TITLE
feat(create): add generate content endpoint

### DIFF
--- a/backend/src/logic/prompt.ts
+++ b/backend/src/logic/prompt.ts
@@ -1,0 +1,4 @@
+
+export async function generateContent(message: string) {
+    return message ;
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -6,11 +6,13 @@ import {
     deleteTodoById,
     getTodoById,
     updateTodoById,
-    createRandomTodo
+    createRandomTodo,
+    generateTodoContent
 } from "./methods";
 
 const forwardRouter = Router();
 forwardRouter.post("/todos", createTodo);
+forwardRouter.post("/todos/:id/generate", generateTodoContent);
 forwardRouter.get("/todos", getAllTodos);
 forwardRouter.get("/todos", getTodosByDate);
 forwardRouter.get("/todos/:id", getTodoById);

--- a/backend/src/routes/methods.ts
+++ b/backend/src/routes/methods.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { v4 } from "uuid";
 import { Todo } from "types/Todo";
+import { generateContent } from "../logic/prompt"
 import fetch from "node-fetch";
 
 // This is not exported, which means only methods exposed in this file will access it.
@@ -28,13 +29,15 @@ export async function createTodo(req: Request, res: Response) {
     if (!("description" in body)) {
         return res.status(400).json({ message: "Input task required" });
     }
-    const newTaskDescription = body.description;
+    const newTodoTitle = body.description;
     const newTodo = {
         id: v4(),
-        description: newTaskDescription,
+        description: newTodoTitle,
+        content: "",
         done: false,
         date: body.date ||= new Date()
     };
+    newTodo.content = await generateContent(newTodoTitle);
     todoList[newTodo.id] = newTodo;
     return res.status(200).json(newTodo);
 }
@@ -97,6 +100,7 @@ export async function createRandomTodo(req: Request, res: Response) {
         const randomTodo = {
             id: v4(),
             description: randomActivity,
+            content: "",
             done: false,
             date: req.body.date ||= new Date()
         };

--- a/backend/src/routes/methods.ts
+++ b/backend/src/routes/methods.ts
@@ -37,9 +37,19 @@ export async function createTodo(req: Request, res: Response) {
         done: false,
         date: body.date ||= new Date()
     };
-    newTodo.content = await generateContent(newTodoTitle);
     todoList[newTodo.id] = newTodo;
     return res.status(200).json(newTodo);
+}
+
+export async function generateTodoContent(req: Request, res: Response) {
+    const { id } = req.params;
+    if (!(id in todoList)) {
+        return badRequest(res, "UUID does not exist");
+    }
+    const todo = todoList[id]
+    todo.content = await generateContent(todo.description);
+    todoList[todo.id] = todo;
+    return res.status(200).json(todo);
 }
 
 // Can mention unused request param

--- a/backend/src/types/Todo.ts
+++ b/backend/src/types/Todo.ts
@@ -1,6 +1,7 @@
 export type Todo = {
     id: string;
-    description: string;
+    description: string,
+    content: string;
     done: boolean;
     date: Date;
 };

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -76,6 +76,47 @@
         }
       }
     },
+    "/api/todos/{id}/generate": {
+      "post": {
+        "tags": ["todo"],
+        "summary": "Generates the content for a task",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/todos"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Cannot.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error",
+                  "example": {
+                    "message": "UUID does not exist"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/todos/{id}": {
       "get": {
         "tags": ["todo"],


### PR DESCRIPTION
Scope:
- Add POST endpoint to generate todo content (`POST /todos/:id/generate`)
- Add placeholder logic component
- Modify notes schema

Test:
- `npm install`
- `docker compose up --build -d`
- `http://localhost:9000/swagger`

Notes
- Unfortunate that the "title" is called "description" but lazy to refactor and break everything