### PR TITLE
feat--openai-python: Refactor logic/prompts, Add python option

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,21 @@
 FROM node:alpine
-
 ARG user="node"
 ARG appdir="/home/node/app"
 
+# Install python & related libraries (no package mgmt for simplicity)
+RUN apk add --no-cache python3 py-pip
+RUN pip install openai==0.27.9
+
+# Create the application dir
 RUN mkdir -p ${appdir} && chown -R ${user} ${appdir}
 WORKDIR ${appdir}
 USER ${user}
 
+# Install node libraries
 COPY --chown=${user} package.json package-lock.json ./
 RUN npm install
 
+# Copy src files etc into dir
 COPY --chown=${user} . .
 
 CMD [ "npm", "run", "dist" ]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^4.18.1",
         "node-fetch": "^2.6.7",
         "openai": "^4.2.0",
+        "python-shell": "^5.0.0",
         "swagger-ui-express": "^4.5.0",
         "uuid": "^9.0.0"
       },
@@ -5900,6 +5901,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/python-shell": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
+      "integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/qs": {
@@ -11791,6 +11800,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "python-shell": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
+      "integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w=="
     },
     "qs": {
       "version": "6.10.3",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "express": "^4.18.1",
         "node-fetch": "^2.6.7",
+        "openai": "^4.2.0",
         "swagger-ui-express": "^4.5.0",
         "uuid": "^9.0.0"
       },
@@ -1497,16 +1498,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
-      "dev": true
+      "version": "18.17.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.9.tgz",
+      "integrity": "sha512-fxaKquqYcPOGwE7tC1anJaPJ0GHyOVzfA2oUoXECjBjrtsIz4YJvtNYsq8LUcjEUehEF+jGpx8Z+lFrtT6z0tg=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -1909,6 +1908,17 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2022,6 +2032,17 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -2140,8 +2161,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -2245,6 +2265,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2447,6 +2472,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -2551,7 +2584,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2657,6 +2689,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssom": {
@@ -2781,7 +2821,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2840,6 +2879,15 @@
       "peer": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -3253,6 +3301,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3495,7 +3551,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3503,6 +3558,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/formidable": {
@@ -3878,6 +3950,14 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3990,6 +4070,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-core-module": {
       "version": "2.10.0",
@@ -5112,6 +5197,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -5231,6 +5326,24 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -5435,6 +5548,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.2.0.tgz",
+      "integrity": "sha512-zfvpO2eITIxIjTG8T6Cek7NB2dMvP/LW0TRUJ4P9E8+qbBNKw00DrtfF64b+fAV2+wUYCVyynT6iSycJ//TtbA==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
       }
     },
     "node_modules/optionator": {
@@ -6927,6 +7058,14 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8298,16 +8437,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
-      "dev": true
+      "version": "18.17.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.9.tgz",
+      "integrity": "sha512-fxaKquqYcPOGwE7tC1anJaPJ0GHyOVzfA2oUoXECjBjrtsIz4YJvtNYsq8LUcjEUehEF+jGpx8Z+lFrtT6z0tg=="
     },
     "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -8593,6 +8730,14 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -8675,6 +8820,14 @@
           "dev": true,
           "peer": true
         }
+      }
+    },
+    "agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "requires": {
+        "humanize-ms": "^1.2.1"
       }
     },
     "ajv": {
@@ -8765,8 +8918,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -8849,6 +9001,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -8991,6 +9148,11 @@
       "dev": true,
       "peer": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -9076,7 +9238,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -9167,6 +9328,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -9275,8 +9441,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -9317,6 +9482,15 @@
       "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true,
       "peer": true
+    },
+    "digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "requires": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
+      }
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -9623,6 +9797,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9828,11 +10007,24 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "requires": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
       }
     },
     "formidable": {
@@ -10107,6 +10299,14 @@
       "dev": true,
       "peer": true
     },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -10189,6 +10389,11 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-core-module": {
       "version": "2.10.0",
@@ -11073,6 +11278,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -11160,6 +11375,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -11307,6 +11527,21 @@
       "peer": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "openai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.2.0.tgz",
+      "integrity": "sha512-zfvpO2eITIxIjTG8T6Cek7NB2dMvP/LW0TRUJ4P9E8+qbBNKw00DrtfF64b+fAV2+wUYCVyynT6iSycJ//TtbA==",
+      "requires": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
       }
     },
     "optionator": {
@@ -12379,6 +12614,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "express": "^4.18.1",
     "node-fetch": "^2.6.7",
+    "openai": "^4.2.0",
     "swagger-ui-express": "^4.5.0",
     "uuid": "^9.0.0"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "express": "^4.18.1",
     "node-fetch": "^2.6.7",
     "openai": "^4.2.0",
+    "python-shell": "^5.0.0",
     "swagger-ui-express": "^4.5.0",
     "uuid": "^9.0.0"
   }

--- a/backend/src/logic/openai_bridge.py
+++ b/backend/src/logic/openai_bridge.py
@@ -29,7 +29,7 @@ def call_openai_api(input: str) -> str:
 
 
 if __name__ == "__main__":
-    # NodeJS will call this script by passing the input as stdin.
+    # NodeJS will call this script and pass the input as stdin.
     input = input()
 
     # Use the input

--- a/backend/src/logic/openai_bridge.py
+++ b/backend/src/logic/openai_bridge.py
@@ -1,0 +1,39 @@
+import openai
+
+# OpenAI Config
+openai.api_key = "<API-KEY>"
+MODEL = "gpt-3.5-turbo"
+
+
+def call_openai_api(input: str) -> str:
+    """
+    Call OpenAI API and returns output from the API.
+    May throw an error if an exception occurred (e.g. invalid API key)
+    Reference: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
+    """
+    response = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": (
+                "You are a helpful assistant that suggest steps to achieving to-dos of a user. "
+                "Read the following task and generate 5 simple steps to achieve it."
+            )},
+            {"role": "user", "content": input},
+        ],
+        # Additional params can be found here:
+        # https://platform.openai.com/docs/api-reference/chat/create
+        max_tokens=200
+    )
+
+    return response['choices'][0]['message']['content']
+
+
+if __name__ == "__main__":
+    # NodeJS will call this script by passing the input as stdin.
+    input = input()
+
+    # Use the input
+    output = call_openai_api(input)
+
+    # Output to stdout so that nodejs can get the output
+    print(output)

--- a/backend/src/logic/prompt.ts
+++ b/backend/src/logic/prompt.ts
@@ -1,15 +1,149 @@
-import OpenAI from 'openai';
+import { PythonShell } from "python-shell";
+import OpenAI from "openai";
 
+// Configuration for OpenAI
 const openai = new OpenAI({
-    apiKey: '<API_KEY>', // defaults to process.env["OPENAI_API_KEY"]
+    apiKey: "<API-KEY>"
 });
+// Other model specific config can be modified in the "callOpenAI" function
 
-export async function generateContent(message: string) {
-    const conversationContext = "You are a helpful assistant that suggest steps to achieving to-dos of a user. Generate 5 steps for this todo:"
+// Typescript types
+type ChatCompletionMessages = Array<OpenAI.Chat.Completions.CreateChatCompletionRequestMessage>;
+type ChatCompletionRole = "function" | "user" | "system" | "assistant";
+const USER: ChatCompletionRole = "user" as ChatCompletionRole;
+const SYSTEM: ChatCompletionRole = "system" as ChatCompletionRole;
+
+/** 
+* This is an older way of calling the openai API, which bundles
+* both the context and the user input together in a single prompt.
+* You may see a few examples online which use this method.
+* @param  {[string]} userInput
+* @return {[Promise<string>]} Returns a Promise that returns the output from openai when executed
+* @throws Error if openai API encounters an error (e.g. invalid API key).
+*/
+export async function callOpenAI(messages: ChatCompletionMessages): Promise<string> {
     const response = await openai.chat.completions.create({
-        messages: [{ role: 'user', content: conversationContext + message }],
-        model: 'gpt-3.5-turbo',
-        max_tokens: 300
+        messages,
+        model: "gpt-3.5-turbo",
+        max_tokens: 200
     });
-    return response.choices;
+    const contentArray = response.choices.map(item => item?.message?.content || "");
+    const mergedContent = contentArray.join(' ');
+    return mergedContent;
+}
+
+/** 
+* This function is not currently in use, but included in the code for demonstration purposes.
+* This is an older way of calling the openai API, which bundles
+* both the context and the user input together in a single prompt.
+* Because the context and user input are passed to the LLM model as one,
+* Additional care needs to be taken to prevent confusion by the model.
+* You may see a few examples online which use this method.
+* @param  {[string]} userInput
+* @return {[Promise<string>]} Returns a Promise that returns the output from openai when executed
+* @throws Error if openai API encounters an error (e.g. invalid API key).
+*/
+export async function basicCompletion(userInput: string): Promise<string> {
+    // Multiple line string is not indented to avoid including it in the string itself
+    const fullPrompt = `You are a helpful assistant that suggest steps to achieving to-dos of a user.
+Generate 5 simple steps for the following task wrapped in triple quotes:
+"""
+${userInput}
+"""
+Steps:`;
+
+    const messages = [{ role: USER, content: fullPrompt }];
+    return await callOpenAI(messages);
+}
+
+/** 
+* This is the newer method of calling the openai API, which separates the context
+* from the user input, allowing developers to simplify the prompt and reduce risk
+* of adversarial attacks to retrieve the prompt context.
+* @param  {[string]} userInput
+* @return {[Promise<string>]} Returns a Promise that returns the output from openai when executed
+* @throws Error if openai API encounters an error (e.g. invalid API key).
+*/
+export async function chatCompletion(userInput: string): Promise<string> {
+    const systemPrompt = `You are a helpful assistant that suggest steps to achieving to-dos of a user
+Read the following task and generate 5 simple steps to achieve it.`;
+    
+    const messages = [
+        { role: SYSTEM, content: systemPrompt },
+        { role: USER, content: userInput }
+    ];
+    return await callOpenAI(messages);
+}
+
+/** 
+* Calls a python script to get a response.
+* This facilitates calling OpenAI using python examples found on the internet.
+* If using this function, ensure the API KEY is set in the python script.
+* @param  {[string]} userInput
+* @return {[Promise<string>]} Returns a Promise that returns the output from python when executed
+* @throws Error if python shell encountered an error.
+*/
+export async function pythonCompletion(userInput: string): Promise<string> {
+    // Wrap the python shell in a promise, and `await` the result
+    // Reference: https://github.com/extrabacon/python-shell/blob/master/index.ts
+    const scriptPath = "src/logic/openai_bridge.py";
+    return new Promise<string>((resolve, reject) => {
+        const pyshell = new PythonShell(scriptPath, {
+            mode: "text",
+            pythonOptions: ["-u"]
+        });
+
+        // Send the output via stdin
+        pyshell.send(userInput);
+
+        // Receive output (from stdout) and return it as the result
+        let output: string[] = [];
+        pyshell.on("message", (message: string) => {
+            output.push(message);
+        }).end((err: any) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            const contentArray = output.map(item => item as string || "");
+            const mergedContent: string = contentArray.join(' ') as string;
+            resolve(mergedContent);
+        });
+        // Throw an exception if any error occurred
+        pyshell.on("stderr", (err: any) => {
+            if (err) {
+                console.error(err);
+                reject(err);
+            }
+        });
+        pyshell.on("error", (err: any) => {
+            if (err) {
+                console.error(err);
+                reject(err);
+            }
+        });
+        pyshell.on("close", (err: any) => {
+            if (err) {
+                console.error(err);
+                reject(err);
+            }
+        });
+    });
+}
+
+/** 
+* Wrapper function to handle any exceptions from the inference functions
+* @param  {[string]} userInput
+* @return {[Promise<string | null>]} Returns a Promise that returns the output as string, or null if errorred out
+*/
+export async function generateContent(userInput: string): Promise<string | null> {
+    try {
+        // Set the function as basicCompletion | chatCompletion | pythonCompletion
+        // based on your implementation
+        return await chatCompletion(userInput);
+    } catch (error) {
+        console.error("Error:", error);
+        return null;
+    }
 }

--- a/backend/src/logic/prompt.ts
+++ b/backend/src/logic/prompt.ts
@@ -1,4 +1,15 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+    apiKey: '<API_KEY>', // defaults to process.env["OPENAI_API_KEY"]
+});
 
 export async function generateContent(message: string) {
-    return message ;
+    const conversationContext = "You are a helpful assistant that suggest steps to achieving to-dos of a user. Generate 5 steps for this todo:"
+    const response = await openai.chat.completions.create({
+        messages: [{ role: 'user', content: conversationContext + message }],
+        model: 'gpt-3.5-turbo',
+        max_tokens: 300
+    });
+    return response.choices;
 }

--- a/backend/src/routes/methods.ts
+++ b/backend/src/routes/methods.ts
@@ -47,19 +47,12 @@ export async function generateTodoContent(req: Request, res: Response) {
         return badRequest(res, "UUID does not exist");
     }
     const todo = todoList[id]
-    try {
-        const openai_response = await generateContent(todo.description);
-        if (openai_response && openai_response.length > 0) {
-            const contentArray = openai_response.map(item => item?.message?.content || "");
-            const mergedContent = contentArray.join(' ');
-            todo.content = mergedContent;
-            todoList[todo.id] = todo;
-            return res.status(200).json(todo);
-        } else {
-            return res.status(500).json({ error: "OpenAI response is empty or invalid" });
-        }
-    } catch (error) {
-        console.error("Error:", error);
+    const generatedText = await generateContent(todo.description);
+    if (generatedText) {
+        todo.content = generatedText;
+        todoList[todo.id] = todo;
+        return res.status(200).json(todo);
+    } else {
         return res.status(500).json({ error: "An error occurred while generating content" });
     }
 }


### PR DESCRIPTION
Scope
- Refactor route/methods.ts, prompt.ts
- Update Dockerfile to include python
- Add nodejs - python bridge
- Add python option

Test:
- Configure api_key in prompt.ts / openai_bridge.py
- Set your preferred method of calling openai API at `generateContent`
- Test procedure is same as https://github.com/Tingweiftw/gt-engineering-bootcamp-2023/pull/2